### PR TITLE
Feat: 사용자 API 추가 구현

### DIFF
--- a/Hana_Bridge_BE-API/src/main/java/com/adela/hana_bridge_beapi/controller/UsersApiController.java
+++ b/Hana_Bridge_BE-API/src/main/java/com/adela/hana_bridge_beapi/controller/UsersApiController.java
@@ -40,6 +40,7 @@ public class UsersApiController {
                 .builder()
                 .email(email)
                 .name(users.getName())
+                .nickname(users.getNickName())
                 .role(users.getRole())
                 .build()
         );

--- a/Hana_Bridge_BE-API/src/main/java/com/adela/hana_bridge_beapi/controller/UsersApiController.java
+++ b/Hana_Bridge_BE-API/src/main/java/com/adela/hana_bridge_beapi/controller/UsersApiController.java
@@ -1,12 +1,16 @@
 package com.adela.hana_bridge_beapi.controller;
 
 import com.adela.hana_bridge_beapi.dto.user.LoginRequest;
+import com.adela.hana_bridge_beapi.dto.user.UserRequest;
 import com.adela.hana_bridge_beapi.dto.user.UserResponse;
+import com.adela.hana_bridge_beapi.dto.user.UsersRegistRequest;
+import com.adela.hana_bridge_beapi.entity.Users;
 import com.adela.hana_bridge_beapi.service.TokenService;
 import com.adela.hana_bridge_beapi.service.UsersService;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseCookie;
@@ -21,9 +25,60 @@ public class UsersApiController {
     private final TokenService tokenService;
 
     //회원가입 API 호출 -> 구현 예정
+    @PostMapping("/user")
+    public ResponseEntity<Void> createUser(@Valid @RequestBody UsersRegistRequest usersRegistRequest) {
+        usersService.registerUser(usersRegistRequest);
+        return ResponseEntity.ok().build();
+    }
+
+    //사용자 정보 조회
+    @GetMapping("/user")
+    public ResponseEntity<UserResponse> getUser(@RequestHeader("Authorization") String authHeader) {
+        String email = getEmailFromHeader(authHeader);
+        Users users = usersService.findByEmail(email);
+        return ResponseEntity.ok().body(UserResponse
+                .builder()
+                .email(email)
+                .name(users.getName())
+                .role(users.getRole())
+                .build()
+        );
+    }
+    //사용자 정보 수정 API
+    @PutMapping("/user")
+    public ResponseEntity<UserResponse> updateUser(@RequestHeader("Authorization") String authHeader, @Valid @RequestBody UserRequest userRequest) {
+        Long userId = getUserIdFromHeader(authHeader);
+        UserResponse userResponse = usersService.updateUser(userId, userRequest);
+
+        return ResponseEntity.ok().body(userResponse);
+    }
+
+    //사용자 탈퇴
+    @DeleteMapping("/user")
+    public ResponseEntity<Void> deleteUser(@RequestHeader("Authorization") String authHeader) {
+        Long userId = getUserIdFromHeader(authHeader);
+        //userId를 이용하여 삭제
+        usersService.deleteUser(userId);
+        return ResponseEntity.ok().build();
+    }
+
+    //Header에 있는 accessToken에서 Email 추출
+    private String getEmailFromHeader(String authHeader) {
+        String accessToken = authHeader.replace("Bearer ", "");
+        return tokenService.findEmailByToken(accessToken);
+    }
+
+    //Header에 있는 accessToken에서 UserId 추출
+    private Long getUserIdFromHeader(String authHeader) {
+        String accessToken = authHeader.replace("Bearer ", "");
+        return tokenService.findUsersIdByToken(accessToken);
+    }
+
+
+
     //로그인 API 호출
     @PostMapping("/user/login")
-    public ResponseEntity<UserResponse> login(@RequestBody LoginRequest loginRequest, HttpServletResponse response) {
+    public ResponseEntity<UserResponse> login(@Valid @RequestBody LoginRequest loginRequest, HttpServletResponse response) {
         UserResponse userResponse = usersService.login(loginRequest.getEmail(), loginRequest.getPassword());
 
         String accessToken = tokenService.createFirstAccessToken(userResponse.getEmail(), userResponse.getRole());

--- a/Hana_Bridge_BE-API/src/main/java/com/adela/hana_bridge_beapi/dto/user/LoginRequest.java
+++ b/Hana_Bridge_BE-API/src/main/java/com/adela/hana_bridge_beapi/dto/user/LoginRequest.java
@@ -1,5 +1,7 @@
 package com.adela.hana_bridge_beapi.dto.user;
 
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -10,6 +12,10 @@ import lombok.Setter;
 @NoArgsConstructor
 @AllArgsConstructor
 public class LoginRequest {
+    @NotBlank(message = "이메일은 필수 입력값입니다.")
+    @Email(message = "이메일 형식이 올바르지 않습니다.")
     private String email;
+
+    @NotBlank(message = "비밀번호는 필수 입력값입니다.")
     private String password;
 }

--- a/Hana_Bridge_BE-API/src/main/java/com/adela/hana_bridge_beapi/dto/user/UserRequest.java
+++ b/Hana_Bridge_BE-API/src/main/java/com/adela/hana_bridge_beapi/dto/user/UserRequest.java
@@ -1,0 +1,14 @@
+package com.adela.hana_bridge_beapi.dto.user;
+
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserRequest {
+    private String email;
+    private String name;
+    private String nickname;
+    private String password;
+}

--- a/Hana_Bridge_BE-API/src/main/java/com/adela/hana_bridge_beapi/dto/user/UserRequest.java
+++ b/Hana_Bridge_BE-API/src/main/java/com/adela/hana_bridge_beapi/dto/user/UserRequest.java
@@ -8,7 +8,6 @@ import lombok.*;
 @AllArgsConstructor
 public class UserRequest {
     private String email;
-    private String name;
     private String nickname;
     private String password;
 }

--- a/Hana_Bridge_BE-API/src/main/java/com/adela/hana_bridge_beapi/dto/user/UsersRegistRequest.java
+++ b/Hana_Bridge_BE-API/src/main/java/com/adela/hana_bridge_beapi/dto/user/UsersRegistRequest.java
@@ -1,0 +1,39 @@
+package com.adela.hana_bridge_beapi.dto.user;
+
+import com.adela.hana_bridge_beapi.entity.Users;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UsersRegistRequest {
+
+    @NotBlank(message = "이메일은 필수 입력값입니다.")
+    @Email(message = "이메일 형식이 올바르지 않습니다.")
+    private String email;
+
+    @NotBlank(message = "이름은 필수 입력값입니다.")
+    private String name;
+
+    @NotBlank(message = "닉네임은 필수 입력값입니다.")
+    private String nickname;
+
+    @NotBlank(message = "비밀번호는 필수 입력값입니다.")
+    private String password;
+
+    public Users toEntity() {
+        return Users.builder()
+                .email(this.email)
+                .name(this.name)
+                .nickName(this.nickname)
+                .role("ROLE_USER")
+                .password(this.password)
+                .build();
+    }
+}

--- a/Hana_Bridge_BE-API/src/main/java/com/adela/hana_bridge_beapi/entity/Users.java
+++ b/Hana_Bridge_BE-API/src/main/java/com/adela/hana_bridge_beapi/entity/Users.java
@@ -35,7 +35,7 @@ public class Users implements UserDetails {
     @Column(name = "oauth_provider", nullable = true)
     private String oauthProvider;
 
-    @Column(name = "oauth_id", nullable = false)
+    @Column(name = "oauth_id", nullable = true)
     private String oauthId;
 
     @Column(name = "role", nullable = false)
@@ -86,6 +86,13 @@ public class Users implements UserDetails {
         this.oauthId = oauthId;
         this.role = role;
         this.createdAt = LocalDateTime.now();
+    }
+
+    //사용자 정보 갱신 시에 해당 필드 값만 변경
+    public void updateUsers(String email, String password, String nickName) {
+        this.email = email;
+        this.password = password;
+        this.nickName = nickName;
     }
 
 

--- a/Hana_Bridge_BE-API/src/main/java/com/adela/hana_bridge_beapi/errorhandler/GlobalExceptionHandler.java
+++ b/Hana_Bridge_BE-API/src/main/java/com/adela/hana_bridge_beapi/errorhandler/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package com.adela.hana_bridge_beapi.errorhandler;
 
 import com.adela.hana_bridge_beapi.dto.error.ErrorResponse;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -11,5 +12,12 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ErrorResponse> handleIllegalArgument(IllegalArgumentException ex) {
         return ResponseEntity.badRequest()
                 .body(new ErrorResponse("BAD_REQUEST", ex.getMessage()));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handleValidation(MethodArgumentNotValidException ex) {
+        String errorMessage = ex.getBindingResult().getFieldError().getDefaultMessage();
+        return ResponseEntity.badRequest()
+                .body(new ErrorResponse("VALIDATION_FAILED", errorMessage));
     }
 }

--- a/Hana_Bridge_BE-API/src/main/java/com/adela/hana_bridge_beapi/service/TokenService.java
+++ b/Hana_Bridge_BE-API/src/main/java/com/adela/hana_bridge_beapi/service/TokenService.java
@@ -23,10 +23,16 @@ public class TokenService {
     private final long EXPIRATION_REFRESH_TIME = 1000 * 60 * 60 * 24;
 
     //-------------Token 공통 기능--------------
+    //Token에서 Users
     public Long findUsersIdByToken(String token) {
         String email = tokenProvider.getEmail(token);
         Users users = usersService.findByEmail(email);
         return users.getId();
+    }
+
+    //Token에서 Email 추출
+    public String findEmailByToken(String token) {
+        return tokenProvider.getEmail(token);
     }
 
     //-------------AccessToken 기능--------------

--- a/Hana_Bridge_BE-API/src/main/java/com/adela/hana_bridge_beapi/service/UsersService.java
+++ b/Hana_Bridge_BE-API/src/main/java/com/adela/hana_bridge_beapi/service/UsersService.java
@@ -38,6 +38,9 @@ public class UsersService {
         Users users = usersRepository.findById(userId)
                 .orElseThrow(()-> new IllegalArgumentException("User not found : " + userId));
 
+        //비밀번호 암호화
+        userRequest.setPassword(bCryptPasswordEncoder.encode(userRequest.getPassword()));
+
         //영속성 이용하여 정보 갱신
         users.updateUsers(
                 userRequest.getEmail(),

--- a/Hana_Bridge_BE-API/src/main/java/com/adela/hana_bridge_beapi/service/UsersService.java
+++ b/Hana_Bridge_BE-API/src/main/java/com/adela/hana_bridge_beapi/service/UsersService.java
@@ -1,9 +1,11 @@
 package com.adela.hana_bridge_beapi.service;
 
-import com.adela.hana_bridge_beapi.config.jwt.TokenProvider;
+import com.adela.hana_bridge_beapi.dto.user.UserRequest;
 import com.adela.hana_bridge_beapi.dto.user.UserResponse;
+import com.adela.hana_bridge_beapi.dto.user.UsersRegistRequest;
 import com.adela.hana_bridge_beapi.entity.Users;
 import com.adela.hana_bridge_beapi.repository.UsersRepository;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -15,12 +17,44 @@ public class UsersService {
     private final UsersRepository usersRepository;
     private final AuthenticationManager authenticationManager;
     private final BCryptPasswordEncoder bCryptPasswordEncoder;
-    //회원가입 메서드 -> 구현 예정
 
-    //회원정보 조회
+    //회원가입 메서드
+    public void registerUser(UsersRegistRequest usersRegistRequest) {
+        //비밀번호 암호화
+        usersRegistRequest.setPassword(bCryptPasswordEncoder.encode(usersRegistRequest.getPassword()));
+
+        usersRepository.save(usersRegistRequest.toEntity());
+    }
+
+    //email 기반 회원정보 조회
     public Users findByEmail(String email) {
         return usersRepository.findByEmail(email)
                 .orElseThrow(()-> new IllegalArgumentException("Email not found : " + email));
+    }
+
+    //사용자 정보 수정
+    @Transactional
+    public UserResponse updateUser(Long userId, UserRequest userRequest) {
+        Users users = usersRepository.findById(userId)
+                .orElseThrow(()-> new IllegalArgumentException("User not found : " + userId));
+
+        //영속성 이용하여 정보 갱신
+        users.updateUsers(
+                userRequest.getEmail(),
+                userRequest.getPassword(),
+                userRequest.getNickname()
+        );
+
+        return UserResponse.builder()
+                .email(users.getEmail())
+                .name(users.getName())
+                .nickname(users.getNickName())
+                .build();
+    }
+
+    //사용자 탈퇴
+    public void deleteUser(Long userId) {
+        usersRepository.deleteById(userId);
     }
 
     //로그인 인증


### PR DESCRIPTION
- 로그인 요청 dto 유효성 검증 어노테이션 추가
- 유효성 검사 시 에러 처리 핸들러 메소드 추가

- 정보 갱신 요청 dto 구현
- 회원 가입 요청 dto 구현

- Token에서 UserId, Email 추출 코드 분리

- 정보 갱신 update 메소드 추가
- UserApiController: 회원가입, 내 정보 조회, 정보 수정, 사용자 탈퇴, 토큰 파싱 내부 메소드 구현
- UserService: 회원가입, 정보 조회, 정보 수정, 사용자 탈퇴 비즈니스 로직 구현

- 사용자 정보 수정 시 name은 대상이 아니므로 제외
- 사용자 정보 수정 시 비밀번호도 인코딩하여 저장