### PR TITLE
Feat/116 로그인 유지 & Al chat 내용 유지 & Board 수정

### DIFF
--- a/Hana_Bridge_FE-Cli/package-lock.json
+++ b/Hana_Bridge_FE-Cli/package-lock.json
@@ -1066,6 +1066,7 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.7.0.tgz",
       "integrity": "sha512-XVwolG6eTqwV0N8z/oDlN93ITCIGIop6leXlGJI/4EKy+0POYkR+ABHRSdGXY+0MQvJBP8yAzh+EYFxTuvmBiQ==",
+      "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.0.0",
         "@standard-schema/utils": "^0.3.0",
@@ -1602,6 +1603,7 @@
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.4.1.tgz",
       "integrity": "sha512-IpEm5ZmeXAP/osiBXVVP5KjFMzbWOonMs0NaQQl+xYnUAcq4oHUBsF2+p4MgKWG4YMmFYJU8A6sxRPuowllm6w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.26.10",
         "@babel/plugin-transform-react-jsx-self": "^7.25.9",
@@ -5453,6 +5455,7 @@
       "version": "9.2.0",
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "license": "MIT",
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -5577,7 +5580,8 @@
     "node_modules/redux": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
-      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w=="
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",

--- a/Hana_Bridge_FE-Cli/src/clientView/Header.jsx
+++ b/Hana_Bridge_FE-Cli/src/clientView/Header.jsx
@@ -6,7 +6,7 @@ import { useSelector } from 'react-redux';
 
 //store action함수 
 import { useDispatch } from 'react-redux';
-import { clearUser } from '../store/userSlice';
+import { clearUser, clearAiChat } from '../store/userSlice';
 
 import ApiClient from "../service/ApiClient";
 
@@ -37,6 +37,8 @@ const BoardHeader = () => {
       dispatch(clearUser());
       console.log("로그아웃 완료!");
       dispatch(clearUser());
+      dispatch(clearAiChat()); 
+      localStorage.removeItem('userState'); //localStorage 비움
     })
     .catch(err =>{
       console.error("로그아웃 중 오류 발생:", err);

--- a/Hana_Bridge_FE-Cli/src/clientView/board/AddBoard.jsx
+++ b/Hana_Bridge_FE-Cli/src/clientView/board/AddBoard.jsx
@@ -80,6 +80,7 @@ const AddBoard = () => {
             onChange={e => setTitle(e.target.value)} />
         </Form.Group>
 
+        {category === 'code' ? (
         <Form.Group className="mb-4">
           <Form.Control
             as="textarea"
@@ -88,7 +89,9 @@ const AddBoard = () => {
             value={code}
             onChange={e => setCode(e.target.value)} />
         </Form.Group>
-
+      ):(
+        <></>
+      )}     
         <Form.Group className="mb-4">
           <Form.Control
             as="textarea"

--- a/Hana_Bridge_FE-Cli/src/clientView/user/MyPage.jsx
+++ b/Hana_Bridge_FE-Cli/src/clientView/user/MyPage.jsx
@@ -5,7 +5,7 @@ import { Form, Card, Modal, Button} from 'react-bootstrap';
 import { useEffect, useState, useRef} from "react";
 import { useSelector, useDispatch } from 'react-redux';
 import { useNavigate, Link } from "react-router-dom";
-import { modifyUser, clearUser } from '../../store/userSlice';
+import { modifyUser, clearUser, clearAiChat } from '../../store/userSlice';
 
 const MyPage = () => {
   const accessToken = useSelector((state) => state.user.accessToken);
@@ -119,6 +119,8 @@ const MyPage = () => {
       alert("정상적으로 탈퇴되었습니다.");
       ApiClient.userLogout();
       dispatch(clearUser());
+      dispatch(clearAiChat());
+      localStorage.removeItem('userState');
       navigate('/');
     })
     .catch((err) => console.error("API 요청 실패:", err));

--- a/Hana_Bridge_FE-Cli/src/store/store.js
+++ b/Hana_Bridge_FE-Cli/src/store/store.js
@@ -1,10 +1,41 @@
 import { configureStore } from '@reduxjs/toolkit';
- import userReducer from './userSlice';
- 
- const store = configureStore({
-   reducer: {
-     user: userReducer,
-   },
- });
- 
- export default store;
+import userReducer from './userSlice';
+
+//localStorage에서 불러오기
+const loadState = () => {
+  try {
+    const serializedState = localStorage.getItem('userState');
+    if (serializedState === null) {
+      return undefined;
+    }
+    return { user: JSON.parse(serializedState) };  // 슬라이스 이름에 맞게
+  } catch (err) {
+    console.error("불러오기 실패", err);
+    return undefined;
+  }
+};
+
+//localStorage에 저장하기
+const saveState = (state) => {
+  try {
+    const serializedState = JSON.stringify(state.user);  // user slice만 저장
+    localStorage.setItem('userState', serializedState);
+  } catch (err) {
+    console.error("저장 실패", err);
+  }
+};
+
+const store = configureStore({
+  reducer: {
+    user: userReducer,
+  },
+  preloadedState: loadState(), // 초기 상태에 localStorage 값 사용
+});
+
+// 상태가 바뀔 때마다 localStorage에 저장
+store.subscribe(() => {
+  saveState(store.getState());
+});
+
+
+export default store;

--- a/Hana_Bridge_FE-Cli/src/store/userSlice.js
+++ b/Hana_Bridge_FE-Cli/src/store/userSlice.js
@@ -6,6 +6,7 @@ import { createSlice } from '@reduxjs/toolkit';
    nickName: 'guest',
    accessToken: 'guest',
    role: 'guest',
+   chatMessages: [],
  };
  
  const userSlice = createSlice({
@@ -31,8 +32,19 @@ import { createSlice } from '@reduxjs/toolkit';
        state.accessToken = null;
        state.role = null;
      },
+     setAiChat: (state, action) => {
+        state.chatMessages = action.payload.chatMessages;
+        console.log(state.chatMessages);
+     },
+     clearAiChat: (state) =>{
+      state.chatMessages = [];
+     },
+     // 전체 상태 초기화
+     resetAll: (state) => {
+      Object.assign(state, initialState); 
+    }    
    },
  });
  
- export const { setUser, modifyUser, clearUser } = userSlice.actions;
+ export const { setUser, modifyUser, clearUser, setAiChat, clearAiChat } = userSlice.actions;
  export default userSlice.reducer;


### PR DESCRIPTION

새로고침 시에 로그인 유지하기
로그아웃 안하고 창을 끄고 다시 접속했을 경우 로그인 유지하기
=> localStorage에 redux 내용 저장해서 해결

AI 채팅 내용 유지 (이전 내용을 불러오시겠습니까? 물어보기 확인시 정보 가져오고 취소 시 redux 내용 초기화)
Board 생성시 notice 버튼 안 보이게 수정